### PR TITLE
Add typings declarations

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,2 @@
+import Component from 'vue-class-component';
+export default Component;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-class-component",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "./dist/index.js",
   "repository": "https://github.com/johnlindquist/nuxt-class-component.git",
   "license": "MIT",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   ],
   "compilerOptions": {
     "outDir": "./dist",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "declaration": true
   }
 }


### PR DESCRIPTION
There were no types declarations, which in this case should be a re-exporting of `vue-class-component`, causing the error `Could not find a declaration file for module 'nuxt-class-component'` to show up