### PR TITLE
Add augmented types for options

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,17 @@
 import Component from 'vue-class-component';
 import { State, Getter, Action, Mutation, namespace } from 'vuex-class';
 export { Component as default, State, Getter, Action, Mutation, namespace };
+
+declare module 'vue/types/options' {
+  // Declare augmentation for Options
+  interface ComponentOptions<
+    V extends Vue,
+    Data=DefaultData<V>,
+    Methods=DefaultMethods<V>,
+    Computed=DefaultComputed,
+    PropsDef=PropsDefinition<DefaultProps>,
+    Props=DefaultProps> {
+
+    middleware: string;
+  }
+}

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -11,7 +11,6 @@ declare module 'vue/types/options' {
     Computed=DefaultComputed,
     PropsDef=PropsDefinition<DefaultProps>,
     Props=DefaultProps> {
-
-    middleware: string;
+    middleware?: string | string[];
   }
 }


### PR DESCRIPTION
Not sure if this is needed but I've detected tscheck errors in this code:

```
import { Vue, Watch } from 'vue-property-decorator';
import Component, { namespace, State, Action } from 'nuxt-class-component';

@Component({
  components: {
    LoadingComponent,
    ChoicerComponent,
    StepperComponent
  },
  middleware: 'secured'
})
export default class extends Vue {
```
And I've resolved it adding to my typings/vue.d.ts 
```
declare module 'vue/types/options' {
  // Declare augmentation for Options
  interface ComponentOptions<
    V extends Vue,
    Data=DefaultData<V>,
    Methods=DefaultMethods<V>,
    Computed=DefaultComputed,
    PropsDef=PropsDefinition<DefaultProps>,
    Props=DefaultProps> {

    middleware: string;
  }
}
```